### PR TITLE
Various changes Feb 2026: Debian 12; ENHANCED_US; keyboard documentation; other

### DIFF
--- a/5250_terminal.py
+++ b/5250_terminal.py
@@ -1376,8 +1376,8 @@ def openSerial(port, speed):
         fcntl.ioctl(fd, termios.TIOCMBIS,  '\x02\x00\x00\x00' )
         fcntl.ioctl(fd, termios.TIOCMBIS,   '\x04\x00\x00\x00' )
     except OSError as e:
-        if e.errno == errno.EINVAL:
-            # This occurs if port isn't a real serial interface.
+        if e.errno in [errno.EINVAL, errno.ENOTTY]:
+            # One of these occurs if port isn't a real serial interface.
             # Ignore it so that PTYs may be used for testing purposes.
             print("Ignoring ioctl() failure for TIOCMBIS (only required for "
                   "WSL)")

--- a/5250_terminal.py
+++ b/5250_terminal.py
@@ -700,6 +700,149 @@ scancodeDictionaries = {
         },
     },
 
+    # NOTES:
+    # - not tested with real hardware
+    # - unlike other mappings, Alt generates an escape prefix instead
+    #   of behaving like an AltGr key
+    'ENHANCED_US': {
+
+        # ESC AND FUNCTION BLOCK KEYS MAPPINGS
+        # KEYS FROM LEFT TO RIGHT
+        'CTRL_PRESS': [0x14],   # CapsLock
+        'CTRL_RELEASE': [0x94], # CapsLock
+        'ALT_PRESS': [0x19, 0x39],   # Left/Right Alt
+        'ALT_RELEASE': [0x99, 0xB9], # Left/Right Alt
+        'SHIFT_PRESS': [0x12, 0x59],   # Left/Right Shift
+        'SHIFT_RELEASE': [0x92, 0xD9], # Left/Right Shift
+        'CAPS_LOCK': [0x11], # Reset
+        'EXTRA': [],
+        0x08: [chr(0x1B), chr(0x1B), '', ''],  # handle Attn as Esc
+
+        # The escape sequences in position 0 correspond to the "xterm"
+        # terminfo entry's key_f1 through key_f12.
+        0x07: [chr(0x1B) + 'OP', '', '', ''], #F1
+        0x0F: [chr(0x1B) + 'OQ', '', '', ''], #F2
+        0x17: [chr(0x1B) + 'OR', '', '', ''], #F3
+        0x1F: [chr(0x1B) + 'OS', '', '', ''], #F4
+        0x27: [chr(0x1B) + '[15~', '', '', ''], #F5
+        0x2F: [chr(0x1B) + '[17~', '', '', ''], #F6
+        0x37: [chr(0x1B) + '[18~', '', '', ''], #F7
+        0x3F: [chr(0x1B) + '[19~', '', '', ''], #F8
+        0x47: [chr(0x1B) + '[20~', '', '', ''], #F9
+        0x4F: [chr(0x1B) + '[21~', '', '', ''], #F10
+        0x56: [chr(0x1B) + '[23~', '', '', ''], #F11
+        0x5E: [chr(0x1B) + '[24~', '', '', ''], #F12
+
+        # MAIN ALPHA BLOCK KEYS MAPPINGS
+        # KEYS FROM TOP TO BOTTOM AND FROM LEFT TO RIGHT
+        # ROW 1
+        0x0E: ['`', '~', '', ''],
+        0x16: ['1', '!', chr(0x1B) + '1', ''],
+        0x1E: ['2', '@', chr(0x1B) + '2', ''],
+        0x26: ['3', '#', chr(0x1B) + '3', ''],
+        0x25: ['4', '$', chr(0x1B) + '4', ''],
+        0x2E: ['5', '%', chr(0x1B) + '5', ''],
+        0x36: ['6', '^', chr(0x1B) + '6', chr(0x1E)],
+        0x3D: ['7', '&', chr(0x1B) + '7', ''],
+        0x3E: ['8', '*', chr(0x1B) + '8', ''],
+        0x46: ['9', '(', chr(0x1B) + '9', ''],
+        0x45: ['0', ')', chr(0x1B) + '0', ''],
+        0x4E: ['-', '_', chr(0x1B) + '-', chr(0x1F)],
+        0x55: ['=', '+', chr(0x1B) + '=', ''],
+        0x66: [chr(0x08), chr(0x08), '', ''],  # BS
+        # ROW 2
+        0x0D: [chr(0x09), chr(0x09), '', ''],  # TAB
+        0x15: ['q', 'Q', chr(0x1B) + 'q', chr(0x11)],
+        0x1D: ['w', 'W', chr(0x1B) + 'w', chr(0x17)],
+        0x24: ['e', 'E', chr(0x1B) + 'e', chr(0x05)],
+        0x2D: ['r', 'R', chr(0x1B) + 'r', chr(0x12)],
+        0x2C: ['t', 'T', chr(0x1B) + 't', chr(0x14)],
+        0x35: ['y', 'Y', chr(0x1B) + 'y', chr(0x19)],
+        0x3C: ['u', 'U', chr(0x1B) + 'u', chr(0x15)],
+        0x43: ['i', 'I', chr(0x1B) + 'i', chr(0x09)],
+        0x44: ['o', 'O', chr(0x1B) + 'o', chr(0x0F)],
+        0x4D: ['p', 'P', chr(0x1B) + 'p', chr(0x10)],
+        0x54: ['[', '{', chr(0x1B) + '[', chr(0x1B)],
+        0x5B: [']', '}', chr(0x1B) + ']', chr(0x1D)],
+        0x5C: ['\\', '|',  chr(0x1B) + '\\', chr(0x1C)],
+        # ROW 3
+        0x1C: ['a', 'A', chr(0x1B) + 'a', chr(0x01)],
+        0x1B: ['s', 'S', chr(0x1B) + 's', chr(0x13)],
+        0x23: ['d', 'D', chr(0x1B) + 'd', chr(0x04)],
+        0x2B: ['f', 'F', chr(0x1B) + 'f', chr(0x06)],
+        0x34: ['g', 'G', chr(0x1B) + 'g', chr(0x07)],
+        0x33: ['h', 'H', chr(0x1B) + 'h', chr(0x08)],
+        0x3B: ['j', 'J', chr(0x1B) + 'j', chr(0x0A)],
+        0x42: ['k', 'K', chr(0x1B) + 'k', chr(0x0B)],
+        0x4B: ['l', 'L', chr(0x1B) + 'l', chr(0x0C)],
+        0x4C: [';', ':', chr(0x1B) + ';', ''],
+        0x52: ['\'', '"', chr(0x1B) + '\'', ''],
+        0x5A: [chr(0x0D), chr(0x0D), chr(0x1B) + chr(0x0D), ''],  # ENTER
+        # ROW 4
+        0x1A: ['z', 'Z', chr(0x1B) + 'z', chr(0x1A)],
+        0x22: ['x', 'X', chr(0x1B) + 'x', chr(0x18)],
+        0x21: ['c', 'C', chr(0x1B) + 'c', chr(0x03)],
+        0x2A: ['v', 'V', chr(0x1B) + 'v', chr(0x16)],
+        0x32: ['b', 'B', chr(0x1B) + 'b', chr(0x02)],
+        0x31: ['n', 'N', chr(0x1B) + 'n', chr(0x0E)],
+        0x3A: ['m', 'M', chr(0x1B) + 'm', chr(0x0D)],
+        0x41: [',', '<', chr(0x1B) + ',', ''],
+        0x49: ['.', '>', chr(0x1B) + '.', ''],
+        0x4A: ['/', '?', chr(0x1B) + '/', chr(0x1F)],
+        # ROW 5
+        0x29: [' ', ' ', '', ''],  # SPACE BAR
+        # Enter key not used
+
+        # TEXT EDIT MODE KEYS BLOCK MAPPINGS
+        # KEYS FROM TOP TO BOTTOM AND FROM LEFT TO RIGHT
+        # TBD
+
+        # ARROW KEYS BLOCK MAPPINGS
+        # KEYS FROM TOP TO BOTTOM AND FROM LEFT TO RIGHT
+        0x63: [chr(0x1B), chr(0x1B), chr(0x1B), '', 'A'],  # UP ARROW
+        0x61: [chr(0x1B), chr(0x1B), chr(0x1B), '', 'D'],  # LEFT ARROW
+        0x60: [chr(0x1B), chr(0x1B), chr(0x1B), '', 'B'],  # DOWN ARROW
+        0x6A: [chr(0x1B), chr(0x1B), chr(0x1B), '', 'C'],  # RIGHT ARROW
+
+        # NUMPAD KEYS BLOCK MAPPINGS
+        # KEYS FROM TOP TO BOTTOM AND FROM LEFT TO RIGHT
+        # ROW 1
+        # 0x76 is blank and is in the position of Num Lock on a 101
+        # key keyboard, so do nothing with it
+        0x77: ['/', '/', '', ''],
+        0x7E: ['*', '*', '', ''],
+        0x7F: ['-', '-', '', ''],
+        # ROW 2
+        0x6C: ['7', '7', '', ''],
+        # NUMPAD 8  EXTRA UP ARROW
+        0x75: ['8', '8', chr(0x1B), chr(0x1B), 'A'],
+        0x7D: ['9', '9', '', ''],
+        # 0x7C doesn't correspond to a key location on a 101 key
+        # keyboard, and is another tab key on the enhanced keyboard,
+        # so do nothing with it
+        # ROW 3
+        # NUMPAD 4   EXTRA LEFT ARROW
+        0x6b: ['4', '4', chr(0x1B), chr(0x1B), 'D'],
+        0x73: ['5', '5', '', ''],
+        # NUMPAD 6 EXTRA RIGHT ARROW
+        0x74: ['6', '6', chr(0x1B), chr(0x1B), 'C'],
+        0x7B: ['+', '+', '', ''],
+        # ROW 4
+        0x69: ['1', '1', '', ''],
+        # NUMPAD 2  EXTRA DOWN ARROW
+        0x72: ['2', '2', chr(0x1B), chr(0x1B), 'B'],
+        0x7A: ['3', '3', '', ''],
+        0x79: [chr(0x0D), '', '', ''],  # ENTER,
+        # ROW 5
+        0x70: ['0', '0', '', ''],
+        0x71: ['.', '', '', ''],
+
+        # Custom character conversions, from ASCII char to EBCDIC code that
+        # will override the DEFAULT_CODEPAGE conversions
+        'CUSTOM_CHARACTER_CONVERSIONS': {
+        },
+    },
+
     '122KEY_DE': {
 
         # SPECIAL FUNCTION KEYS MAPPINGS

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ When displaying the converted ASCII characters in the 5250 terminal with your se
 
 This will, for example for the third entry map the `^` ASCII character to the `0x95` EBCDIC character (n) for the terminal that uses this keyboard mapping.
 
+The `txchartable` command available via the [command line interface](#command-line-interface) may be useful to view the glyphs that can be displayed by your terminal and their corresponding EBCDIC code points which may be used in the mapping above.
+
 
 
 ## Command line interface

--- a/README.md
+++ b/README.md
@@ -248,14 +248,33 @@ The keyboard of a 5250 terminal doesn’t directly generate characters, instead 
 
 ATM I have no idea how to make a proper autodiscovery and autoconfiguration for every terminal-keyboard-language combination, so the user will need to configure this editing the 5250_terminal.py script. This is also a matter of personal preference because the older terminals have weird key legends and non-standard layouts, and the user will have to decide the key mappings that better suits his preference.
 
+There appear to be five major physical keyboard layouts supported by 5250 terminals:
+
+| Layout name(s) | Summary
+| -------------- | -------
+| (__"5250" or "5251"__) __"Typewriter"__/__"Data processing"__/__"Standard"__ | Supported by the 5251 and other early terminal models.
+| (__"5250" or "5251"__) __"Data entry"__ | Supported by the 5251 and other early terminal models.  Unlike __5250 Typewriter__, these have no separate numeric keypad, but instead share the keypad with the alphabetic keys.  There are 66, 67 and 69-key variants.
+| __"Enhanced"__ | Only supported by later terminals.  These have almost the same physical layout as a standard PC 101 or 102-key keyboard, but they have an additional key in place of the top half of the modern numeric keypad's <kbd>+</kbd> key.
+| __"122-key Typewriter"__/__"122-key Data processing"__ | Only supported by later terminals.  These notably have function keys F1 through F24 in two rows at the top of the keyboard.
+| __"122-key Data entry"__ | Only supported by later terminals.  Same physical layout as the other 122-key keyboard, but generates some different scan codes.
+
+[Further details about keyboard variants](doc/keyboards.md)
+
 There is at the beginning of the script a dictionary definition called __`scancodeDictionaries`__. That dictionary has one entry for each keyboard mapping available, you have the following mappings available:
 
-* __5250_ES__ is a mapping for a Spanish keyboard 5250 terminal
-* __5250_US__ is a mapping for an English-US keyboard 5250 terminal
-* __5250_DE__ is a mapping for a German keyboard 5250 terminal
-* __ENHANCED_ES__ is a mapping for an enhanced (IBM model M 101-102 key) keyboard terminal
-* __ENHANCED_DE__ is a mapping for an enhanced (IBM model M 101-102 key) keyboard terminal
-* __122KEY_DE__ is a mapping for a German keyboard 122 key terminal
+| Physical layout: | 5250 Typewriter | Enhanced      | 122-key Typewriter                          |
+| ---------------- | --------------- | ------------- | ------------------------------------------- |
+| German           | `5250_DE`       | `ENHANCED_DE` | `122KEY_DE`                                 |
+| Spanish          | `5250_ES`       | `ENHANCED_ES` | *missing*                                   |
+| US English       | `5250_US`       | `ENHANCED_US` | `122KEY_EN`, `122KEY_EN_CUSTOM`<sup>1</sup> |
+
+Table notes:
+* *missing* indicates that this mapping has not (yet) been written
+1. see the comments in [5250_terminal.py](5250_terminal.py) for a description of and important information about this mapping
+
+Notes on support for keyboards with no mapping shown above:
+* __Data entry__ physical layouts: While no mappings are supplied, the mappings for the __Typewriter__ physical layouts may work as the two layouts share scan codes.  However, the omission of numerous keys and changes in key labels might necessitate the creation of specific mappings for such keyboards.
+* __Katakana__ physical layout variants: All five physical layouts have Katakana variants.  It is not known whether the existing mappings can be used with these keyboards with the additional keys simply having no effect, or whether separate mappings would be required.
 
 Refer to [SC41-5605-00 AS/400e series __Workstation Customization Programming__ Version 4, First Edition (September 1998)](https://public.dhe.ibm.com/systems/power/docs/systemi/v6r1/en_US/sc415605.pdf) for more information about layouts and the scancodes generated.
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ There is at the beginning of the script a dictionary definition called __`scanco
 * __ENHANCED_DE__ is a mapping for an enhanced (IBM model M 101-102 key) keyboard terminal
 * __122KEY_DE__ is a mapping for a German keyboard 122 key terminal
 
-Refer to this [document](ftp://ftp.www.ibm.com/systems/power/docs/systemi/v6r1/en_US/sc415605.pdf) for more information about layouts and the scancodes generated.
+Refer to [SC41-5605-00 AS/400e series __Workstation Customization Programming__ Version 4, First Edition (September 1998)](https://public.dhe.ibm.com/systems/power/docs/systemi/v6r1/en_US/sc415605.pdf) for more information about layouts and the scancodes generated.
 
 To change the default mapping used if no mapping is specified in the command line, you have to edit the value of the variable `DEFAULT_SCANCODE_DICTIONARY`
 

--- a/doc/keyboards.md
+++ b/doc/keyboards.md
@@ -1,0 +1,54 @@
+# Additional information about keyboards for 5250-series terminals
+
+## Major physical keyboard layouts
+
+[SA21-9247-6 IBM 5250 Information Display System __Functions Reference Manual__, Seventh Edition (March 1987) page 2-118](https://bitsavers.org/pdf/ibm/5250_5251/SA21-9247-6_IBM_5250_Information_Display_System_Functions_Reference_Manual_198703.pdf#page=170) has diagrams of the first four major layouts described below.  The two 122-key layouts differ only in scan codes, not key locations.
+
+### "5250/5251 Typewriter", "5250/5251 Data processing", "Standard"
+
+These are reasonably different from a modern keyboard, but not as different as the __5250/5251 Data entry__ variant described below.
+
+Further information and photos are available from [Admiral Shark's Keyboards](https://sharktastica.co.uk/wiki/ibm-model-b#525X-83).
+
+References for naming:
+* "Typewriter": [GA21-9246-4 IBM 5250 Information Display System __Introduction__, Fifth Edition (January 1980) page 26](https://bitsavers.org/pdf/ibm/5250_5251/GA21-9246-4_5250_Information_Display_System_Introduction_Jan80.pdf#page=33)
+* "Data processing": [5250 Information Display System to System/36, System/38, and Application System/400 System Units __Product Attachment Information__ (October 1989) page 13, figure 4](https://bitsavers.org/pdf/ibm/5250_5251/5250_Information_Display_System_to_S36_S38_AS400_System_Units_Product_Attachment_Information_198910.pdf#page=31)
+* "Standard": [SY31-0461-0 IBM __5251 Display Station Model 11 Maintenance Information Manual__, First Edition (December 1977) page 1-35](https://bitsavers.org/pdf/ibm/5250_5251/SY31-0461-0_5251_Display_Station_Model_11_Maintenance_Information_Dec77.pdf#page=54)
+
+### "5250/5251 Data entry"
+
+In contrast to the __5250/5251 Typewriter__ keyboard, these have neither a dedicated numeric keypad, nor numeric keys in the row above the alphabetic keys.  Instead, they have a numeric keypad that is overlaid with the alphabetic keys, similar many modern laptops.
+
+These keyboards were available with a __Proof Arrangement Feature__, which meant that the numeric keypad overlay was arranged like a modern keyboard, with <kbd>7</kbd>, <kbd>8</kbd> and <kbd>9</kbd> at the top.  By default - without this feature - the numeric keypad was arranged with <kbd>7</kbd>, <kbd>8</kbd> and <kbd>9</kbd> at the bottom.  Reference: [GA21-9246-4 IBM 5250 Information Display System __Introduction__, Fifth Edition (January 1980) page 27](https://bitsavers.org/pdf/ibm/5250_5251/GA21-9246-4_5250_Information_Display_System_Introduction_Jan80.pdf#page=34)
+
+Further information and photos are available from [Admiral Shark's Keyboards](https://sharktastica.co.uk/wiki/ibm-model-b#525X-66).
+
+### "Enhanced"
+
+These have almost the same physical layout as a standard PC 101 or 102-key keyboard, but they have an additional key in place of the top half of the numeric keypad <kbd>+</kbd> key.  Many of the non-alphanumeric keys have different labels though.
+
+* US: 102 keys
+* Japan: 104 keys
+* Other: 103 keys
+
+### "122-key Typewriter", "122-key Data processing"
+
+These may also be referred to as "3180 Model 2" (or "3180-2") "and 3196" data processing keyboards.
+
+The most obvious additions vs. an __Enhanced__ keyboard are a second row of function keys (<kbd>F13</kbd> through <kbd>F24</kbd>) at the top of the keyboard, 10 keys on the left which bear some similarity to those on a __Standard__ keyboard, and a modified layout for the cursor keys.
+
+There is also a 124-key Japanese Katakana variant.
+
+### "122-key Data entry"
+
+Similarly to the other 122-key layout, these may be referred to as "3180-2 and 3196".  Reference: [5250 Information Display System to System/36, System/38, and Application System/400 System Units __Product Attachment Information__ (October 1989) page 199](https://bitsavers.org/pdf/ibm/5250_5251/5250_Information_Display_System_to_S36_S38_AS400_System_Units_Product_Attachment_Information_198910.pdf#page=217)
+
+These appear to have keys in the same locations as a __122-key Typewriter__ keyboard, but some generate different scan codes, and they presumably have different labels.
+
+Most documentation shows the typewriter layout first, or only the typewriter layout, so these do not appear to have been the standard 122-key variant.
+
+## Other information
+
+[S131-0620-4 IBM __5251 Display Station Models 1 and 11 Parts Catalog__, Fifth Edition (June 1979)](https://bitsavers.org/pdf/ibm/5250_5251/S131-0620-4_5251_Display_Station_Models_1_and_11_Parts_Catalog_Jun79.pdf) provides some additional information about *Standard*/*Typewriter-like* and *Data processing* keyboards:
+* Page 5 lists the available combinations of major variant and region/language/layout.
+* Pages 8-18 show part numbers by key number/position and language for the major variants.  These part numbers do not appear to be defined elsewhere, but can be used to make some comparisons between language variants where no photos or layout diagrams are available.

--- a/etc/twinax_bashrc_example
+++ b/etc/twinax_bashrc_example
@@ -9,10 +9,12 @@
 # set would also work.
 . ~/.bashrc
 
-# These are defined with unwanted --color=auto options:
-unalias egrep
-unalias fgrep
-unalias grep
+# These may be defined with unwanted --color=auto options:
+for alias in egrep fgrep grep ls; do
+    if [[ -v BASH_ALIASES[$alias] ]]; then
+	unalias $alias
+    fi
+done
 
 # If 5250_terminal.py is started under X, since $DISPLAY is still set,
 # running "emacs" will by default start it in the X session where


### PR DESCRIPTION
This is a collection of a few unrelated things and other somewhat-related things.

I didn't test any of this with actual hardware, only with my (still unreleased, sorry) emulator.

Notes on commits, in order from oldest to newest:

# Code changes

## Extend ignoring of failure of TIOCMBIS ioctl() to newer kernels

This is a trivial change I found was required to run on Debian 12.  I *assume* it's the kernel change that causes a different `errno` to be returned.

I think my testing is sufficient for this one as the error only occurs when using the emulator anyway.

## etc/twinax_bashrc_example: Avoid 'unalias' errors; unalias 'ls'

Further changes required for Debian 12, in one of the example `bashrc` files.

I think testing this with my emulator is fine as it's pretty isolated from anything hardware-related.

## Add ENHANCED_US keyboard mapping

I started on this 20 months ago as I thought I was going to have the opportunity to work with a clone terminal that I think may accept a standard PC PS/2 keyboard, but that hasn't eventuated yet and it might be a long time before it does, so I was only able to test with my emulator.  The change clearly doesn't touch anything else so I think it doesn't need regression testing to make sure it didn't break other mappings or anything.

I could have obviously made mistakes in the mapping that are cancelled out by the emulator, so I understand if you'd prefer to not accept this addition on the basis that it might not work with a real keyboard - I could just put it on a branch in my fork for now, in which case I would need to update `README.md` in one of the following commits to not refer to it.  However, I think that even if it has errors, it should be a useful starting point for someone.

If I recall correctly, it would not be useful to test this with an emulation program running on a PC connected to the USB converter via twinax, as those emulation programs don't have very direct keyboard mappings themselves.

# Documentation changes

## README.md: Fix broken link to document with layouts and scan codes

Oops, I think I never noticed that there was a link here until I worked on the commit below, and also think I never looked at this document previously!  At some point I should add some references to the documents I've been referring to, but for now at least this link works again.

## Identify and document physical keyboard layouts

I wanted to add the new `ENHANCED_US` mapping added above, plus the missing `122KEY_EN` and `122KEY_EN_CUSTOM`.  While doing that, it seemed like it would be useful to turn the list of mappings into a table, but this (and my emulator) necessitated figuring out what the keyboards are meant to be called, and it seemed worth documenting what I learned and decided on.

What things should be called, what is documented and how it is documented are all certainly subjective, so I'm happy to make any changes you suggest.

:star: Note to self: If you're happy with the physical keyboard layout names I've used in these changes, I need to change my emulator to stop using the name "standard".

## README.md: The txchartable command may be useful for CUSTOM_CHARACTER_CONVERSIONS

Unrelated to any of the above, but I just noticed this while making the other changes in `README.md`.